### PR TITLE
ignore node_modules after running the app locally

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -3,3 +3,4 @@
 !src/
 !package.json
 !package-lock.json
+node_modules/


### PR DESCRIPTION
If you run the app locally, it creates the node_modules directory. When pushing it to Cloud Foundry also this directory is pushed as well. It would be better to exclude the directory node_modules from the uploaded files. This would decrease the size of the files to upload and avoid possible conflicts generated by the local modules.